### PR TITLE
Fix the condition about skipping over creating symbolic link in the setup script

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -57,7 +57,7 @@ function link_to_homedir() {
   local dotdir
   dotdir=$(dirname ${script_dir})
 
-  if [[ "$HOME" != "$dotdir" ]];then
+  if [[ "$HOME" == "$dotdir" ]];then
     command echo "Skipped: Source and destination are the same ($HOME)."
     return
   fi


### PR DESCRIPTION
- セットアップスクリプト内でシンボリックリンク作成をスキップする条件が間違っていたため修正